### PR TITLE
Remove all unsafe usage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ crc = "1.2"
 rand = "0.3"
 
 [build-dependencies]
-syntex = "0.24"
+syntex = "0.25"
 tl_macros = { path = "tl_macros" }

--- a/src/rpc/encryption/mod.rs
+++ b/src/rpc/encryption/mod.rs
@@ -1,5 +1,4 @@
 use super::{Session, RpcRes, RpcError};
-use std::mem;
 use std::io::{Read, Write, Cursor};
 use crypto::digest::Digest;
 use crypto::sha1::Sha1;
@@ -51,8 +50,8 @@ fn do_encrypt_message<W: Write>(session: &Session, unencrypted: &Unencrypted, st
 }
 
 pub fn decrypt_message<R: Read>(session: &Session, stream: &mut R) -> RpcRes<Vec<u8>> {
-    let mut key_id: [u8; 8] = unsafe { mem::uninitialized() };
-    let mut msg_key: MsgKey = unsafe { mem::uninitialized() };
+    let mut key_id: [u8; 8] = Default::default();
+    let mut msg_key: MsgKey = Default::default();
     
     try!(stream.read_exact(&mut key_id));
     try!(stream.read_exact(&mut msg_key));
@@ -89,6 +88,7 @@ pub fn decrypt_message<R: Read>(session: &Session, stream: &mut R) -> RpcRes<Vec
     Ok(decrypted_buffer)
 }
 
+#[derive(Default)]
 struct AuthKey {
     pub key_id: [u8; 8],
     pub aes_key: [u8; 32],
@@ -203,10 +203,9 @@ fn make_client_auth_key(session: &Session, msg_key: &[u8; 16]) -> AuthKey {
     let aes_key_raw = [ &sha1_a[0..8], &sha1_b[8..20], &sha1_c[4..16] ];
     let aes_iv_raw = [ &sha1_a[8..20], &sha1_b[0..8], &sha1_c[16..20], &sha1_d[0..8] ];
     
-    let mut result = AuthKey { ..unsafe{ mem::uninitialized() } };
+    let mut result: AuthKey = Default::default();
     set_slice_parts(&mut result.key_id, &[ &key_id_raw[0..8] ]);
     set_slice_parts(&mut result.aes_key, &aes_key_raw);
     set_slice_parts(&mut result.aes_iv, &aes_iv_raw);
     result
 }
-

--- a/tests/bool.rs
+++ b/tests/bool.rs
@@ -6,6 +6,7 @@ use mtproto::tl::Bool;
 use mtproto::tl::parsing::{ReadContext, WriteContext};
 use byteorder::{ByteOrder, LittleEndian, WriteBytesExt};
 
+#[derive(Default)]
 struct BoolTest {
     true_buffer: [u8; 4],
     false_buffer: [u8; 4],
@@ -13,7 +14,7 @@ struct BoolTest {
 
 impl BoolTest {
     fn new() -> BoolTest {
-        let mut test: BoolTest = unsafe { std::mem::uninitialized() };
+        let mut test: BoolTest = Default::default();
         LittleEndian::write_u32(&mut test.true_buffer, 0x997275b5);
         LittleEndian::write_u32(&mut test.false_buffer, 0xbc799737);
         test
@@ -42,4 +43,3 @@ fn bool_deserialization() {
     let false_value: Bool = ReadContext::new(Cursor::new(&data.false_buffer[..])).read_generic().unwrap();
     assert_eq!(false_value, Bool(false));
 }
-

--- a/tl_macros/Cargo.toml
+++ b/tl_macros/Cargo.toml
@@ -5,11 +5,11 @@ authors = ["Connor Hilarides <connorcpu@live.com>"]
 build = "build.rs"
 
 [dependencies]
-syntex = "0.24"
-syntex_syntax = "0.24"
+syntex = "0.25"
+syntex_syntax = "0.25"
 aster = { version = "0.9", features = ["with-syntex"] }
 quasi = { version = "0.3.11", features = ["with-syntex"] }
 
 [build-dependencies]
-syntex = "0.24"
+syntex = "0.25"
 quasi_codegen = { version = "0.3.11", features = ["with-syntex"] }


### PR DESCRIPTION
No need for all this transmuting and uninitialized memory. I didn't see any committed benchmarks to compare against but I'm sure this isn't going to be a big deal.

Also includes a syntex update since I couldn't build without it.