### PR TITLE
Resolve deprecations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ byteorder = "1"
 chrono = "0.3"
 crc = "1.2"
 error-chain = "0.10"
-openssl = "0.9.7"
+openssl = "0.9.17"
 rand = "*"
 
 [build-dependencies.tl_codegen]

--- a/src/rpc/encryption/asymm.rs
+++ b/src/rpc/encryption/asymm.rs
@@ -61,7 +61,7 @@ impl RsaPublicKey {
         }
         let mut hasher = hash::Hasher::new(hash::MessageDigest::sha1())?;
         hasher.update(&buf.into_inner())?;
-        Ok(hasher.finish()?)
+        Ok(hasher.finish2().map(|b| b.to_vec())?)
     }
 
     pub fn fingerprint(&self) -> Result<i64> {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -299,7 +299,7 @@ fn sha1_bytes(parts: &[&[u8]]) -> Result<Vec<u8>> {
     for part in parts {
         hasher.update(part)?;
     }
-    Ok(hasher.finish()?)
+    Ok(hasher.finish2().map(|b| b.to_vec())?)
 }
 
 fn sha1_nonces(nonces: &[Int128]) -> Result<Vec<u8>> {
@@ -310,7 +310,7 @@ fn sha1_nonces(nonces: &[Int128]) -> Result<Vec<u8>> {
         LittleEndian::write_i64(&mut tmp[8..], nonce.1);
         hasher.update(&tmp)?;
     }
-    Ok(hasher.finish()?)
+    Ok(hasher.finish2().map(|b| b.to_vec())?)
 }
 
 pub trait RpcFunction: ::tl::WriteType {


### PR DESCRIPTION
Some deprecations were introduced in `openssl` 0.9.11.